### PR TITLE
3.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.github.reviversmc.themodindex.api"
-version = "2.1.1"
+version = "3.0.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/data/IndexJson.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/data/IndexJson.kt
@@ -15,10 +15,10 @@ data class IndexJson(val schemaVersion: String?, val files: List<IndexFile>) {
      * A file entry found in the index.json file.
      *
      * @param identifier The identifier of the mod file, in the format "modLoader:modName:version".
-     * @param sha1Hash  The SHA-1 hash of the mod file.
+     * @param sha512Hash  The SHA-512 hash of the mod file.
      * @author ReviversMC
-     * @since 1.0.0-2.0.0
+     * @since 3.0.0
      */
     @kotlinx.serialization.Serializable
-    data class IndexFile(val identifier: String?, val sha1Hash: String?)
+    data class IndexFile(val identifier: String?, val sha512Hash: String?)
 }

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/data/ManifestJson.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/data/ManifestJson.kt
@@ -55,17 +55,17 @@ data class ManifestJson(
      *
      * @param fileName     The name of the file, should not be used for version checking.
      * @param mcVersions   A list of Minecraft versions the file is compatible with.
-     * @param sha1Hash     The sha1 hash of the file.
+     * @param sha512Hash     The sha512 hash of the file.
      * @param downloadUrls A list of urls to download the file from.
      * @param curseDownloadAvailable Whether the file is available on Curse. A further api call to CF is required to get the download url.
      * @author ReviversMC
-     * @since 2.1.0
+     * @since 3.0.0
      */
     @kotlinx.serialization.Serializable
     data class ManifestFile(
         val fileName: String?,
         val mcVersions: List<String>,
-        val sha1Hash: String?,
+        val sha512Hash: String?,
         val downloadUrls: List<String>,
         val curseDownloadAvailable: Boolean?
     )

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/DefaultApiDownloader.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/DefaultApiDownloader.kt
@@ -18,7 +18,7 @@ import okhttp3.Request
  * */
 class DefaultApiDownloader(
     private val okHttpClient: OkHttpClient,
-    unEditedRepositoryUrlAsString: String = "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v1",
+    unEditedRepositoryUrlAsString: String = "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v2",
     private val json: Json = Json {
         ignoreUnknownKeys = true
         prettyPrint = true

--- a/src/test/kotlin/ApiDownloadTest.kt
+++ b/src/test/kotlin/ApiDownloadTest.kt
@@ -21,7 +21,8 @@ class ApiDownloadTest {
     fun `should return default manifest index`() {
         val infoDownloader = DefaultApiDownloader(okHttpClient) //Use default repo url.
         assertEquals(
-            "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v1", infoDownloader.repositoryUrlAsString
+            "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v${schemaVersion.split(".")[0]}",
+            infoDownloader.repositoryUrlAsString
         )
     }
 
@@ -57,7 +58,8 @@ class ApiDownloadTest {
             IndexJson(
                 schemaVersion, listOf(
                     IndexJson.IndexFile(
-                        identifier, "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9"
+                        identifier,
+                        "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9"
                     )
                 )
             ), infoDownloader.downloadIndexJson()

--- a/src/test/kotlin/ApiDownloadTest.kt
+++ b/src/test/kotlin/ApiDownloadTest.kt
@@ -11,7 +11,7 @@ class ApiDownloadTest {
 
     private val endpoint = "https://fakelocalhost/fakeindex"
     private val identifier = "bricks:fakemod:1.2.0+bricks-1.18.2"
-    private val schemaVersion = "1.1.0"
+    private val schemaVersion = "2.0.0"
 
     //NOTE: The interceptor and all url calls must end with a '/'!
     private val interceptor = MockInterceptor()
@@ -57,7 +57,7 @@ class ApiDownloadTest {
             IndexJson(
                 schemaVersion, listOf(
                     IndexJson.IndexFile(
-                        identifier, "47a013e660d408619d894b20806b1d5086aab03b"
+                        identifier, "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9"
                     )
                 )
             ), infoDownloader.downloadIndexJson()
@@ -75,7 +75,7 @@ class ApiDownloadTest {
                     ManifestJson.ManifestFile(
                         identifier.split(":")[2],
                         listOf("1.18.2"),
-                        "47a013e660d408619d894b20806b1d5086aab03b",
+                        "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9",
                         emptyList(),
                         false
                     )
@@ -87,7 +87,7 @@ class ApiDownloadTest {
             ManifestJson.ManifestFile(
                 identifier.split(":")[2],
                 listOf("1.18.2"),
-                "47a013e660d408619d894b20806b1d5086aab03b",
+                "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9",
                 emptyList(),
                 false
             ), infoDownloader.downloadManifestFileEntry(identifier)

--- a/src/test/resources/fakeIndex/mods/bricks/fakemod.json
+++ b/src/test/resources/fakeIndex/mods/bricks/fakemod.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "2.0.0",
   "fancyName": "Fake Mod",
   "author": "Fake Author",
   "license": "AGPL-3.0",
@@ -21,7 +21,7 @@
       "mcVersions": [
         "1.18.2"
       ],
-      "sha1Hash": "47a013e660d408619d894b20806b1d5086aab03b",
+      "sha512Hash": "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9",
       "downloadUrls": [],
       "curseDownloadAvailable": false
     }

--- a/src/test/resources/fakeIndex/mods/index.json
+++ b/src/test/resources/fakeIndex/mods/index.json
@@ -3,7 +3,7 @@
   "files": [
     {
       "identifier": "bricks:fakemod:1.2.0+bricks-1.18.2",
-      "sha1Hash": "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9"
+      "sha512Hash": "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9"
     }
   ]
 }

--- a/src/test/resources/fakeIndex/mods/index.json
+++ b/src/test/resources/fakeIndex/mods/index.json
@@ -1,9 +1,9 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "2.0.0",
   "files": [
     {
       "identifier": "bricks:fakemod:1.2.0+bricks-1.18.2",
-      "sha1Hash": "47a013e660d408619d894b20806b1d5086aab03b"
+      "sha1Hash": "1c88ae7e3799f75d73d34c1be40dec8cabbd0f6142b39cb5bdfb32803015a7eea113c38e975c1dd4aaae59f9c3be65eebeb955868b1a10ffca0b6a6b91f8cac9"
     }
   ]
 }

--- a/src/test/resources/fakemod
+++ b/src/test/resources/fakemod
@@ -1,0 +1,1 @@
+Hello world! (Yes this isn't actually a runnable jar)


### PR DESCRIPTION
Breaks backwards compatibility by

- supporting v2 of index instead of v1 of index, which has breaking changes (usage of sha512 instead of sha1)
- changing default repo to v2 instead of v1 of the-mod-index