### PR TITLE
4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.github.reviversmc.themodindex.api"
-version = "3.0.1"
+version = "4.0.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/data/IndexJson.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/data/IndexJson.kt
@@ -3,13 +3,13 @@ package com.github.reviversmc.themodindex.api.data
 /**
  * Represents the index.json file found in the mod index.
  *
- * @param schemaVersion The schema version of the index.json file.
+ * @param indexVersion The schema version of the index.json file.
  * @param files         The [IndexFile] entries found in the index.json file.
  * @author ReviversMC
  * @since 3.0.1
  */
 @kotlinx.serialization.Serializable
-data class IndexJson(val schemaVersion: String, val files: List<IndexFile>) {
+data class IndexJson(val indexVersion: String, val files: List<IndexFile>) {
 
     /**
      * A file entry found in the index.json file.

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/data/ManifestJson.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/data/ManifestJson.kt
@@ -3,11 +3,11 @@ package com.github.reviversmc.themodindex.api.data
 /**
  * A manifest for a mod. The same mod meant for different mod loaders (e.g. Quilt, Fabric, Forge, etc.) will have different manifests.
  *
- * @param schemaVersion The version of the manifest schema.
+ * @param indexVersion The version of the manifest schema.
  * @param fancyName     The user readable name of the project.
  * @param author        The author/publisher of the mod.
  * @param license       The license of the mod, or a url if custom.
- * @param curseForgeId  The curseforge id of the mod, not the slug.
+ * @param curseForgeId  The curseforge id of the mod.
  * @param modrinthId    The modrinth id of the mod, not the slug.
  * @param links         A list of links related to the mod.
  * @param files         File versions for the mod.
@@ -16,11 +16,11 @@ package com.github.reviversmc.themodindex.api.data
  */
 @kotlinx.serialization.Serializable
 data class ManifestJson(
-    val schemaVersion: String,
+    val indexVersion: String,
     val fancyName: String?,
     val author: String,
     val license: String?,
-    val curseForgeId: String?,
+    val curseForgeId: Int?,
     val modrinthId: String?,
     val links: ManifestLinks?,
     val files: List<ManifestFile>

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/DefaultApiDownloader.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/DefaultApiDownloader.kt
@@ -18,7 +18,7 @@ import okhttp3.Request
  * */
 class DefaultApiDownloader(
     private val okHttpClient: OkHttpClient,
-    unEditedRepositoryUrlAsString: String = "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v2",
+    unEditedRepositoryUrlAsString: String = "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v3",
     private val json: Json = Json {
         ignoreUnknownKeys = true
         prettyPrint = true

--- a/src/test/kotlin/ApiDownloadTest.kt
+++ b/src/test/kotlin/ApiDownloadTest.kt
@@ -11,9 +11,8 @@ class ApiDownloadTest {
 
     private val endpoint = "https://fakelocalhost/fakeindex"
     private val identifier = "bricks:fakemod:1.2.0+bricks-1.18.2"
-    private val schemaVersion = "2.0.0"
+    private val schemaVersion = "3.0.0"
 
-    //NOTE: The interceptor and all url calls must end with a '/'!
     private val interceptor = MockInterceptor()
     private val okHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build()
 

--- a/src/test/resources/fakeIndex/mods/bricks/fakemod.json
+++ b/src/test/resources/fakeIndex/mods/bricks/fakemod.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.0.0",
+  "indexVersion": "3.0.0",
   "fancyName": "Fake Mod",
   "author": "Fake Author",
   "license": "AGPL-3.0",

--- a/src/test/resources/fakeIndex/mods/index.json
+++ b/src/test/resources/fakeIndex/mods/index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.0.0",
+  "indexVersion": "3.0.0",
   "files": [
     {
       "identifier": "bricks:fakemod:1.2.0+bricks-1.18.2",


### PR DESCRIPTION
Breaking changes to support v3 of the-mod-index

- schemaVersion renamed to indexVersion
- curseForgeId is now an Int instead of a String