### PR TITLE
5.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.github.reviversmc.themodindex.api"
-version = "5.1.1"
+version = "5.1.2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/ApiDownloader.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/ApiDownloader.kt
@@ -42,6 +42,7 @@ interface ApiDownloader {
      * @author ReviversMC
      * @since 5.1.0
      */
+    @Deprecated("This method offers no advantages over #downloadIndexJson. Use that instead. To be removed in next major release (6.0.0)", ReplaceWith("downloadIndexJson()"))
     @ExperimentalSerializationApi
     suspend fun asyncDownloadIndexJson(): IndexJson?
 
@@ -60,6 +61,7 @@ interface ApiDownloader {
      * @author ReviversMC
      * @since 5.1.0
      */
+    @Deprecated("This method offers no advantages over #getOrDownloadIndexJson. Use that instead. To be removed in next major release (6.0.0)", ReplaceWith("getOrDownloadIndexJson()"))
     @ExperimentalSerializationApi
     suspend fun getOrAsyncDownloadIndexJson(): IndexJson?
 
@@ -84,6 +86,7 @@ interface ApiDownloader {
      * @author ReviversMC
      * @since 5.1.0
      */
+    @Deprecated("This method offers no advantages over #downloadManifestJson. Use that instead. To be removed in next major release (6.0.0)", ReplaceWith("downloadManifestJson(genericIdentifier)"))
     @ExperimentalSerializationApi
     suspend fun asyncDownloadManifestJson(genericIdentifier: String): ManifestJson?
 
@@ -106,6 +109,7 @@ interface ApiDownloader {
      * @author ReviversMC
      * @since 5.1.0
      */
+    @Deprecated("This method offers no advantages over #downloadManifestFileEntry. Use that instead. To be removed in next major release (6.0.0)", ReplaceWith("downloadManifestFileEntry(identifier)"))
     @ExperimentalSerializationApi
     suspend fun asyncDownloadManifestFileEntry(identifier: String): ManifestJson.ManifestFile?
 }

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/DefaultApiDownloader.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/DefaultApiDownloader.kt
@@ -20,9 +20,9 @@ import retrofit2.awaitResponse
  * @since 1.0.0-2.0.0
  */
 class DefaultApiDownloader(
-    private val okHttpClient: OkHttpClient,
+    okHttpClient: OkHttpClient,
     unEditedRepositoryUrlAsString: String = "https://raw.githubusercontent.com/ReviversMC/the-mod-index/v4/",
-    private val json: Json = Json {
+    json: Json = Json {
         ignoreUnknownKeys = true
         prettyPrint = true
     }
@@ -47,6 +47,10 @@ class DefaultApiDownloader(
         return indexJson
     }
 
+    @Deprecated(
+        "This method offers no advantages over #downloadIndexJson. Use that instead. To be removed in next major release (6.0.0)",
+        replaceWith = ReplaceWith("downloadIndexJson()")
+    )
     @ExperimentalSerializationApi
     override suspend fun asyncDownloadIndexJson(): IndexJson? {
         indexJson = indexApiCall.callIndex().awaitResponse().body()
@@ -56,6 +60,10 @@ class DefaultApiDownloader(
     @ExperimentalSerializationApi
     override fun getOrDownloadIndexJson(): IndexJson? = indexJson ?: downloadIndexJson()
 
+    @Deprecated(
+        "This method offers no advantages over #getOrDownloadIndexJson. Use that instead. To be removed in next major release (6.0.0)",
+        replaceWith = ReplaceWith("getOrDownloadIndexJson()")
+    )
     @ExperimentalSerializationApi
     override suspend fun getOrAsyncDownloadIndexJson(): IndexJson? = indexJson ?: asyncDownloadIndexJson()
 
@@ -75,6 +83,10 @@ class DefaultApiDownloader(
         return null
     }
 
+    @Deprecated(
+        "This method offers no advantages over #downloadManifestJson. Use that instead. To be removed in next major release (6.0.0)",
+        replaceWith = ReplaceWith("downloadManifestJson(genericIdentifier)")
+    )
     @ExperimentalSerializationApi
     override suspend fun asyncDownloadManifestJson(genericIdentifier: String): ManifestJson? {
         indexJson ?: getOrAsyncDownloadIndexJson() //Ensure that we have a valid index.
@@ -106,6 +118,10 @@ class DefaultApiDownloader(
         return null
     }
 
+    @Deprecated(
+        "This method offers no advantages over #downloadManifestFileEntry. Use that instead. To be removed in next major release (6.0.0)",
+        replaceWith = ReplaceWith("downloadManifestFileEntry(identifier)")
+    )
     @ExperimentalSerializationApi
     override suspend fun asyncDownloadManifestFileEntry(identifier: String): ManifestJson.ManifestFile? {
         indexJson ?: getOrAsyncDownloadIndexJson() //Ensure that we have a valid index.


### PR DESCRIPTION
Remove poorly implemented and misleading asynchronous methods, which offered no improvements over the synchronous methods. Should async behaviour be intended, use the synchronous methods inside a coroutine/await block.