### PR TITLE
9.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.github.reviversmc.themodindex.api"
-version = "9.0.0"
+version = "9.1.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/data/ManifestJson.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/data/ManifestJson.kt
@@ -1,5 +1,7 @@
 package com.github.reviversmc.themodindex.api.data
 
+import kotlinx.serialization.Serializable
+
 /**
  * A manifest for a mod. The same mod meant for different mod loaders (e.g. Quilt, Fabric, Forge, etc.) will have different manifests.
  *
@@ -15,7 +17,7 @@ package com.github.reviversmc.themodindex.api.data
  * @author ReviversMC
  * @since 7.2.1
  */
-@kotlinx.serialization.Serializable
+@Serializable
 data class ManifestJson(
     val indexVersion: String,
     val genericIdentifier: String,
@@ -37,18 +39,23 @@ data class ManifestJson(
  * @author ReviversMC
  * @since 6.1.0
  */
-@kotlinx.serialization.Serializable
-data class ManifestLinks(val issue: String?, val sourceControl: String?, val others: List<OtherLink>) {
+@Serializable
+data class ManifestLinks(
+    val issue: String?,
+    val sourceControl: String?,
+    val others: List<OtherLink>,
+) {
 
     /**
      * A list of other links related to the mod.
+     * DEPRECATION WARNING: In the next major release, OtherLink will be moved
      *
      * @param linkName The type of link, like "discord", "irc", or "GitHub wiki"
      * @param url      The url of the link.
      * @author ReviversMC
      * @since 6.1.0
      */
-    @kotlinx.serialization.Serializable
+    @Serializable
     data class OtherLink(val linkName: String, val url: String)
 }
 
@@ -64,7 +71,7 @@ data class ManifestLinks(val issue: String?, val sourceControl: String?, val oth
  * @author ReviversMC
  * @since 9.0.0
  */
-@kotlinx.serialization.Serializable
+@Serializable
 data class VersionFile(
     val fileName: String,
     val mcVersions: List<String>,
@@ -82,6 +89,111 @@ data class VersionFile(
  * @author ReviversMC
  * @since 7.2.0
  */
-@kotlinx.serialization.Serializable
+@Serializable
 data class RelationsToOtherMods(val required: List<String>, val incompatible: List<String>)
 
+/**
+ * A manifest for a mod. The same mod meant for different mod loaders (e.g. Quilt, Fabric, Forge, etc.) will have different manifests.
+ *
+ * @param indexVersion The version of the manifest schema.
+ * @param genericIdentifier The generic identifier of the manifest (i.e. "{mod loader}:{mod name}")
+ * @param fancyName     A user readable name of the project.
+ * @param author        The author/publisher of the mod.
+ * @param license       The license of the mod, or a url if custom.
+ * @param curseForgeId  The curseforge id of the mod.
+ * @param modrinthId    The modrinth id of the mod, not the slug.
+ * @param links         A list of links related to the mod.
+ * @param files         File versions for the mod.
+ * @param overrides     A list of overrides for the mod. Data present here should be already reflected on the rest of the fields.
+ * @author ReviversMC
+ * @since 9.1.0
+ */
+@Serializable
+data class ManifestJsonWithOverrides(
+    val indexVersion: String,
+    val genericIdentifier: String,
+    val fancyName: String,
+    val author: String,
+    val license: String?,
+    val curseForgeId: Int?,
+    val modrinthId: String?,
+    val links: ManifestLinks,
+    val files: List<VersionFile>,
+    val overrides: Overrides?,
+)
+
+/**
+ * The possible overrideable fields in the manifest.
+ *
+ * @param genericIdentifier The generic identifier of the manifest (i.e. "{mod loader}:{mod name}")
+ * @param fancyName     A user readable name of the project.
+ * @param author        The author/publisher of the mod.
+ * @param license       The license of the mod, or a url if custom.
+ * @param curseForgeId  The curseforge id of the mod.
+ * @param modrinthId    The modrinth id of the mod, not the slug.
+ * @param links         A list of links related to the mod.
+ * @param files         File versions for the mod.
+ * @author ReviversMC
+ * @since 9.1.0
+ */
+@Serializable
+data class Overrides(
+    val genericIdentifier: String?,
+    val fancyName: String?,
+    val author: String?,
+    val license: String?,
+    val curseForgeId: Int?,
+    val modrinthId: String?,
+    val links: ManifestOverrideLinks?,
+    val files: OverrideSelection<List<VersionOverrideFile>>?,
+)
+
+/**
+ * Selections for the overrides, intended mainly at Lists to override. [replace] is valued over [remove], and [remove] is valued over [add].
+ *
+ * @param add The items to add to [T]
+ * @param remove The items to remove from [T]
+ * @param replace The items to replace [T] with
+ * @author ReviversMC
+ * @since 9.1.0
+ */
+@Serializable
+data class OverrideSelection<T>(val add: T?, val remove: List<String>?, val replace: T?)
+
+/**
+ * Overridden links related to the mod.
+ *
+ * @param issue         A link to the mod's issue tracker.
+ * @param sourceControl A link to the mod's source control, no mirrors. Remove endings like ".git".
+ * @param others        A list of other links related to the mod.
+ * @author ReviversMC
+ * @since 9.1.0
+ */
+@Serializable
+data class ManifestOverrideLinks(
+    val issue: String?,
+    val sourceControl: String?,
+    val others: OverrideSelection<ManifestLinks.OtherLink>?,
+)
+
+/**
+ * Overridden file versions for the mod.
+ *
+ * @param fileName     The name of the file, should not be used for version checking.
+ * @param mcVersions   A list of Minecraft versions the file is compatible with.
+ * @param shortSha512Hash The short SHA512 hash of the file, consisting of only 15 characters.
+ * @param downloadUrls A list of urls to download the file from.
+ * @param curseDownloadAvailable Whether the file is available on Curse. A further api call to CF is required to get the download url.
+ * @param relationsToOtherMods The relations (i.e. dependencies/conflicts) to other mods.
+ * @author ReviversMC
+ * @since 9.1.0
+ */
+@Serializable
+data class VersionOverrideFile(
+    val fileName: String,
+    val mcVersions: OverrideSelection<List<String>>,
+    val shortSha512Hash: String,
+    val downloadUrls: OverrideSelection<List<String>>,
+    val curseDownloadAvailable: Boolean,
+    val relationsToOtherMods: OverrideSelection<RelationsToOtherMods>,
+)

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/ApiDownloader.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/ApiDownloader.kt
@@ -2,6 +2,7 @@ package com.github.reviversmc.themodindex.api.downloader
 
 import com.github.reviversmc.themodindex.api.data.IndexJson
 import com.github.reviversmc.themodindex.api.data.ManifestJson
+import com.github.reviversmc.themodindex.api.data.ManifestJsonWithOverrides
 import com.github.reviversmc.themodindex.api.data.VersionFile
 import java.io.IOException
 
@@ -45,13 +46,27 @@ interface ApiDownloader {
     fun getOrDownloadIndexJson(): IndexJson?
 
     /**
-     * Retrieves the requested [ManifestJson] file for the given [genericIdentifier]. The format for a generic identifier is "modLoader:modName".
+     * Retrieves the requested [ManifestJson] file for the given [genericIdentifier].
+     * The format for a generic identifier is "modLoader:modName".
      * @throws [IOException] if the download fails.
      * @author ReviversMC
      * @since 1.0.0-2.0.0
      */
     @kotlin.jvm.Throws(IOException::class)
     fun downloadManifestJson(genericIdentifier: String): ManifestJson?
+
+    /**
+     * Retrieves the requested [ManifestJsonWithOverrides] file for the given [genericIdentifier].
+     * The format for a generic identifier is "modLoader:modName".
+     *
+     * For most consumers of TMI, [downloadManifestJson] is more than sufficient.
+     * Overrides are mostly for internal tools such as the [TMI-Maintainer](https://github.com/reviversmc/the-mod-index-creator)
+     * @throws [IOException] if the download fails.
+     * @author ReviversMC
+     * @since 9.1.0
+     */
+    @kotlin.jvm.Throws(IOException::class)
+    fun downloadManifestJsonWithOverrides(genericIdentifier: String): ManifestJsonWithOverrides?
 
     /**
      * Retrieves the requested [VersionFile] for the given [identifier].

--- a/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/IndexApiCall.kt
+++ b/src/main/kotlin/com/github/reviversmc/themodindex/api/downloader/IndexApiCall.kt
@@ -2,6 +2,7 @@ package com.github.reviversmc.themodindex.api.downloader
 
 import com.github.reviversmc.themodindex.api.data.IndexJson
 import com.github.reviversmc.themodindex.api.data.ManifestJson
+import com.github.reviversmc.themodindex.api.data.ManifestJsonWithOverrides
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -15,5 +16,10 @@ interface IndexApiCall {
 
     @GET("{modLoader}/{modName}.json")
     fun manifest(@Path("modLoader") modLoader: String, @Path("modName") modName: String): Call<ManifestJson>
+
+    @GET("{modLoader}/{modName}.json")
+    fun manifestWithOverrides(@Path("modLoader") modLoader: String, @Path("modName") modName: String): Call<ManifestJsonWithOverrides>
+
+
 
 }

--- a/src/test/resources/fakeIndex/mods/bricks/fake-mod.json
+++ b/src/test/resources/fakeIndex/mods/bricks/fake-mod.json
@@ -1,5 +1,5 @@
 {
-  "indexVersion": "5.0.0",
+  "indexVersion": "5.2.0",
   "genericIdentifier": "bricks:fake-mod",
   "fancyName": "Fake Mod",
   "author": "Fake Author",

--- a/src/test/resources/fakeIndex/mods/index.json
+++ b/src/test/resources/fakeIndex/mods/index.json
@@ -1,5 +1,5 @@
 {
-  "indexVersion": "5.0.0",
+  "indexVersion": "5.2.0",
   "identifiers": [
     "bricks:fake-mod:1c88ae7e3799f75"
   ],


### PR DESCRIPTION
Update for support version 5.2.0 of the index, and small qol changes for Java users

Version 5.1.0 of the index is **NOT** supported. That version accidentally had backwards incompatible changes, and should never be used